### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
 
       
-    - uses: elgohr/Publish-Docker-Github-Action@v4
+    - uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         GIT_COMMIT: $(git rev-parse HEAD)
       with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore